### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 obj-m += ath_masker.o
-KDIR= /lib/modules/$(shell uname -r)/build
+KDIR ?= /lib/modules/$(shell uname -r)/build
+PWD := $(shell pwd)
 all: 
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules 
+	$(MAKE) -C $(KDIR)  M=$(PWD)
 clean: 
 	rm -rf *.o *.ko *.mod.* .c* .t*


### PR DESCRIPTION
This allows ath_masker to build against modern(ish) kernels.

Build tested against 5.7.6, 5.8.0-rc3, 5.6.0-kali2-amd64(5.6.14), 4.19.118(rpi) and 4.15.
